### PR TITLE
Added function to totally export a flipnote

### DIFF
--- a/PPM.py
+++ b/PPM.py
@@ -895,7 +895,7 @@ if __name__ == '__main__':
 			# If a frame has an associated sound effect, get which sound effect to use
 			sfx = line.split(":")[1].strip() if line.strip() != "" else ""
 			if sfx != "": # If a sound effect must be played...
-				length = frame//fps
+				length = frame/float(fps)
 				print "Adding "+sfx+" at {length} seconds into the video.".format(length=length)
 				# ...run each command in series with the correct arguments
 				with open(os.devnull,"w") as null:

--- a/PPM.py
+++ b/PPM.py
@@ -895,7 +895,7 @@ if __name__ == '__main__':
 			# If a frame has an associated sound effect, get which sound effect to use
 			sfx = line.split(":")[1].strip() if line.strip() != "" else ""
 			if sfx != "": # If a sound effect must be played...
-				length = frame*fps
+				length = frame//fps
 				print "Adding "+sfx+" at {length} seconds into the video.".format(length=length)
 				# ...run each command in series with the correct arguments
 				with open(os.devnull,"w") as null:

--- a/PPM.py
+++ b/PPM.py
@@ -12,14 +12,26 @@
 #	- Jsafive for supplying .tmb files
 #	- Austin Burk, Midmad on hatena haiku and WDLmaster on hcs64.com for determining the sound codec
 #
-import sys, wave, audioop, re#needs os and time aswell in CMD mode
+import sys, wave, audioop, re, os #needs os and time aswell in CMD mode (UPDATE 2018/07/04: os used to get devnull for discarding subprocess output)
 import numpy as np
+import subprocess # used for ffmpeg
 try:
 	from PIL import Image
 	hasPIL = True
 except ImportError:
 	print "Warning: PIL not found, image extraction won't work!"
 	hasPIL = False
+# Test for ffmpeg by executing ffmpeg -h; an OSError indicates ffmpeg is not installed
+
+try:
+	with open(os.devnull,"w") as null:
+		subprocess.call(["ffmpeg","-h"],
+						stdout=null,
+						stderr=null)
+	hasffmpeg = True
+except OSError:
+	print "Warning: ffmpeg not found, video export unavailable. Please make sure ffmepg is installed and can be accessed on your path."
+	hasffmpeg = False
 
 #helpers:
 def AscDec(ascii, LittleEndian=False):#Converts a ascii string into a decimal

--- a/PPM.py
+++ b/PPM.py
@@ -868,11 +868,11 @@ if __name__ == '__main__':
 
 		# Now to make the video in ffmpeg
 		print "Exporting video with ffmpeg..."
-		export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-i","{path}/sounds/BGM.wav".format(path=tempdir),"-c:v","libx264","-c:a","pcm_s16le","-shortest","-y",out_file]
+		export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-i","{path}/sounds/BGM.wav".format(path=tempdir),"-c:v","libx264","-preset","veryslow","-c:a","pcm_s16le","-shortest","-y",out_file]
 		if not os.path.isfile(tempdir+"/sounds/BGM.wav"):
 			print "No background music. Adding silent track..."
 			#has_bgm = False
-			export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-f","lavfi","-i","anullsrc=r=8192:cl=mono","-c:v","libx264","-c:a","pcm_s16le","-shortest","-y",out_file]
+			export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-f","lavfi","-i","anullsrc=r=8192:cl=mono","-c:v","libx264","-preset","veryslow","-c:a","pcm_s16le","-shortest","-y",out_file]
 		else:
 			#has_bgm = True
 			pass
@@ -900,8 +900,9 @@ if __name__ == '__main__':
 		# The second concatenates the silent track and the sound effect, producing a sound file that can be mixed into the video's audio track so that it plays at the correct time.
 		SFX_command = ["ffmpeg","-i","{path}/silence.wav","-i","{path}/sounds/{sfx}.wav","-filter_complex","[0:a] [1:a] concat=n=2:v=0:a=1","-y","{path}/sfx.wav"]
 		# The third mixes the silence+sound effect into the video file
-		merge_command = ["ffmpeg","-i",out_file,"-i","{path}/sfx.wav","-filter_complex","[0:a][1:a] amix=inputs=2:duration=longest","-c:a","pcm_s16le","-c:v","copy","-y","{path}/temp_out.mkv"]
+		merge_command = ["ffmpeg","-i",out_file,"-i","{path}/sfx.wav","-filter_complex","[0:a][1:a] amix=inputs=2:duration=longest:dropout_transition={video_length},volume=2","-c:a","pcm_s16le","-c:v","copy","-max_muxing_queue_size","1024","-y","{path}/temp_out.mkv"]
 
+##        normalise_command = ["ffmpeg","-i",out_file,"-filter_complex","dynaudnorm","{path}/temp_out.mkv".format(path=tempdir)]
 ##        for sfx in ["SFX1","SFX2","SFX3"]:
 ##            if not os.path.isfile("{path}/sounds/{sfx}.wav".format(path=tempdir,sfx=sfx)):
 ##                print sfx+" does not exist."
@@ -926,11 +927,16 @@ if __name__ == '__main__':
 				with open(os.devnull,"w") as null:
 					subprocess.call([i.format(path=tempdir,sfx=sfx,length=length) for i in silence_command],stdout=null,stderr=null)
 					subprocess.call([i.format(path=tempdir,sfx=sfx) for i in SFX_command],stdout=null,stderr=null)
-					subprocess.call([i.format(path=tempdir) for i in merge_command],stdout=null,stderr=null)
-				os.remove(out_file)
-				shutil.move("{path}/temp_out.mkv".format(path=tempdir),out_file)
+					subprocess.call([i.format(path=tempdir,video_length=fps*len(sfx_usage)) for i in merge_command],stdout=null,stderr=null)
+					os.remove(out_file)
+					shutil.move("{path}/temp_out.mkv".format(path=tempdir),out_file)
 				print "Done!"
 				time.sleep(sleep_time) # optional sleep -- in case you want to slow things down for HDD strain or reliability or something
+
+##        subprocess.call(normalise_command)
+##        os.remove(out_file)
+##        shutil.move("{path}/temp_out.mkv".format(path=tempdir),out_file)
+				
 
 		# Remove the temp dir and all files in it
 		print "Removing temporary directory..."

--- a/PPM.py
+++ b/PPM.py
@@ -851,6 +851,11 @@ if __name__ == '__main__':
 			export_command.pop(7)
 			export_command.pop(8)
 		subprocess.call(export_command)
+
+		# Now I'll need to insert sound effects
+		# I can probably do this with ffmpeg by extending the audio with leading silence and using ffmpeg -i video.mkv -i gallop.ogg -filter_complex "[0:0][1:0] amix=inputs=2:duration=longest" main.ogg
+		# or at least something similar
+		# it'll need some experimentation. I'll have to do it another day.
 		
 	else:
 		print "Error!\nThere's no such mode."

--- a/PPM.py
+++ b/PPM.py
@@ -864,7 +864,8 @@ if __name__ == '__main__':
 			export_command.pop(8)
 		else:
 			has_bgm = True
-		subprocess.call(export_command)
+		with open(os.devnull) as null:
+			subprocess.call(export_command,stdout=null,stderr=null)
 		print "Done!"
 
 		# These are the ffmpeg commands I need for each sound effect
@@ -882,7 +883,7 @@ if __name__ == '__main__':
 ##            else:
 
 		# Read in the sound effect usage data
-		print "Reading in sound effect usage..."
+		print "Reading sound effect usage..."
 		with open("{path}/sounds/SFX usage.txt".format(path=tempdir),"r") as sfx_usage_file:
 			sfx_usage = sfx_usage_file.read().split("\n")
 		print "Done!"
@@ -894,11 +895,13 @@ if __name__ == '__main__':
 			sfx = line.split(":")[1].strip() if line.strip() != "" else ""
 			if sfx != "": # If a sound effect must be played...
 				length = frame*fps
-				print "Adding "+sfx+" {length} seconds in.".format(length=length)
+				print "Adding "+sfx+" at {length} seconds into the video.".format(length=length)
 				# ...run each command in series with the correct arguments
-				subprocess.call([i.format(path=tempdir,sfx=sfx,length=length) for i in silence_command])
-				subprocess.call([i.format(path=tempdir,sfx=sfx) for i in SFX_command])
-				subprocess.call([i.format(path=tempdir) for i in merge_command])
+				with open(os.devnull,"w") as null:
+					subprocess.call([i.format(path=tempdir,sfx=sfx,length=length) for i in silence_command],stdout=null,stderr=null)
+					subprocess.call([i.format(path=tempdir,sfx=sfx) for i in SFX_command],stdout=null,stderr=null)
+					subprocess.call([i.format(path=tempdir) for i in merge_command],stdout=null,stderr=null)
+				print "Done!"
 				time.sleep(sleep_time) # optional sleep -- in case you want to slow things down for HDD strain or reliability or something
 
 		# Remove the temp dir and all files in it

--- a/PPM.py
+++ b/PPM.py
@@ -857,11 +857,11 @@ if __name__ == '__main__':
 
 		# Now to make the video in ffmpeg
 		print "Exporting video with ffmpeg..."
-		export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-i","{path}/sounds/BGM.wav".format(path=tempdir),"-c:v","libx264","-shortest","-y",out_file]
+		export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-i","{path}/sounds/BGM.wav".format(path=tempdir),"-c:v","libx264","-c:a","pcm_s16le","-shortest","-y",out_file]
 		if not os.path.isfile(tempdir+"/sounds/BGM.wav"):
 			print "No background music. Adding silent track..."
 			#has_bgm = False
-			export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-f","lavfi","-i","anullsrc=r=8192:cl=mono","-c:v","libx264","-shortest","-y",out_file]
+			export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-f","lavfi","-i","anullsrc=r=8192:cl=mono","-c:v","libx264","-c:a","pcm_s16le","-shortest","-y",out_file]
 		else:
 			#has_bgm = True
 			pass
@@ -875,7 +875,7 @@ if __name__ == '__main__':
 		# The second concatenates the silent track and the sound effect, producing a sound file that can be mixed into the video's audio track so that it plays at the correct time.
 		SFX_command = ["ffmpeg","-i","{path}/silence.wav","-i","{path}/sounds/{sfx}.wav","-filter_complex","[0:a] [1:a] concat=n=2:v=0:a=1","-y","{path}/sfx.wav"]
 		# The third mixes the silence+sound effect into the video file
-		merge_command = ["ffmpeg","-i",out_file,"-i","{path}/sfx.wav","-filter_complex","[0:a][1:a] amix=inputs=2:duration=longest","-c:v","copy","-y",out_file]
+		merge_command = ["ffmpeg","-i",out_file,"-i","{path}/sfx.wav","-filter_complex","[0:a][1:a] amix=inputs=2:duration=longest","-c:a","pcm_s16le","-c:v","copy","-y","{path}/temp_out.mkv"]
 
 ##        for sfx in ["SFX1","SFX2","SFX3"]:
 ##            if not os.path.isfile("{path}/sounds/{sfx}.wav".format(path=tempdir,sfx=sfx)):
@@ -902,6 +902,8 @@ if __name__ == '__main__':
 					subprocess.call([i.format(path=tempdir,sfx=sfx,length=length) for i in silence_command],stdout=null,stderr=null)
 					subprocess.call([i.format(path=tempdir,sfx=sfx) for i in SFX_command],stdout=null,stderr=null)
 					subprocess.call([i.format(path=tempdir) for i in merge_command],stdout=null,stderr=null)
+				os.remove(out_file)
+				shutil.move("{path}/temp_out.mkv".format(path=tempdir),out_file)
 				print "Done!"
 				time.sleep(sleep_time) # optional sleep -- in case you want to slow things down for HDD strain or reliability or something
 

--- a/PPM.py
+++ b/PPM.py
@@ -479,23 +479,23 @@ class TMB:
 		#if ppm: self = ppm
 		
 		out = ["PARA",#magic
-		       DecAsc(self.AudioOffset-0x6a0, 4, True),#animation data size
-		       DecAsc(self.AudioLenght, 4, True),#audio data size
-		       DecAsc(self.FrameCount-1, 2, True),#frame count
-		       "\x24\x00",#unknown
-		       chr(self.Locked), "\0",#locked
-		       DecAsc(self.ThumbnailFrameIndex, 2, True),#which frame is in the thumbnnail
-		       self.OriginalAuthorName.encode("UTF-16LE") + "\0\0"*(11-len(self.OriginalAuthorName)),#Original Author Name
-		       self.EditorAuthorName.encode("UTF-16LE") + "\0\0"*(11-len(self.EditorAuthorName)),#Editor Author Name
-		       self.Username.encode("UTF-16LE") + "\0\0"*(11-len(self.Username)),#Username
+			   DecAsc(self.AudioOffset-0x6a0, 4, True),#animation data size
+			   DecAsc(self.AudioLenght, 4, True),#audio data size
+			   DecAsc(self.FrameCount-1, 2, True),#frame count
+			   "\x24\x00",#unknown
+			   chr(self.Locked), "\0",#locked
+			   DecAsc(self.ThumbnailFrameIndex, 2, True),#which frame is in the thumbnnail
+			   self.OriginalAuthorName.encode("UTF-16LE") + "\0\0"*(11-len(self.OriginalAuthorName)),#Original Author Name
+			   self.EditorAuthorName.encode("UTF-16LE") + "\0\0"*(11-len(self.EditorAuthorName)),#Editor Author Name
+			   self.Username.encode("UTF-16LE") + "\0\0"*(11-len(self.Username)),#Username
 			   self.OriginalAuthorID.decode("HEX")[::-1],#OriginalAuthorID
 			   self.EditorAuthorID.decode("HEX")[::-1],#EditorAuthorID
 			   self.OriginalFilenameC,#OriginalFilename
 			   self.CurrentFilenameC,#CurrentFilename
 			   self.PreviousEditAuthorID.decode("HEX")[::-1],#EditorAuthorID
 			   self.PartialFilenameC,#PartialFilename
-		       DecAsc(self.Date, 4, True),#Date in seconds
-		       "\0\0",#padding
+			   DecAsc(self.Date, 4, True),#Date in seconds
+			   "\0\0",#padding
 			   self.PackThumbnail()]#thumbnail
 		
 		return "".join(out)
@@ -592,26 +592,26 @@ def WriteImage(image, outputPath):
 	return True
 
 def get_metadata(flipnote):
-        meta = {
-        u"Current filename":flipnote.CurrentFilename[:-3]+filetype,
-        u"Original filename":flipnote.OriginalFilename[:-3]+filetype,
-        u"Number of frames":flipnote.FrameCount,
-        u"Locked":flipnote.Locked,
-        u"Thumbnail frame index":(flipnote.ThumbnailFrameIndex+1),
-        u"Original author":flipnote.OriginalAuthorName,
-        u"Editor author":flipnote.EditorAuthorName,
-        u"Username":flipnote.Username,
-        u"Original author ID":flipnote.OriginalAuthorID,
-        u"Editor author ID":flipnote.EditorAuthorID,
-        u"Date(seconds since 1'st Jan 2000)":flipnote.Date,
-        u"Date":time.strftime("%H:%M %d/%m-%Y (faulty)", time.gmtime(epoch+flipnote.Date)),
-        }
-        if filetype == "ppm":
-                meta[u"Frame speed"]=flipnote.Framespeed
-                meta[u"Frame speed"]=flipnote.BGMFramespeed
-                meta[u"Looped"]=flipnote.Looped
-                
-        return meta
+	meta = {
+	u"Current filename":flipnote.CurrentFilename[:-3]+filetype,
+	u"Original filename":flipnote.OriginalFilename[:-3]+filetype,
+	u"Number of frames":flipnote.FrameCount,
+	u"Locked":flipnote.Locked,
+	u"Thumbnail frame index":(flipnote.ThumbnailFrameIndex+1),
+	u"Original author":flipnote.OriginalAuthorName,
+	u"Editor author":flipnote.EditorAuthorName,
+	u"Username":flipnote.Username,
+	u"Original author ID":flipnote.OriginalAuthorID,
+	u"Editor author ID":flipnote.EditorAuthorID,
+	u"Date(seconds since 1'st Jan 2000)":flipnote.Date,
+	u"Date":time.strftime("%H:%M %d/%m-%Y (faulty)", time.gmtime(epoch+flipnote.Date)),
+	}
+	if filetype == "ppm":
+		meta[u"Frame speed"]=flipnote.Framespeed
+		meta[u"Frame speed"]=flipnote.BGMFramespeed
+		meta[u"Looped"]=flipnote.Looped
+			
+	return meta
 
 
 if __name__ == '__main__':
@@ -765,23 +765,22 @@ if __name__ == '__main__':
 			f.write(newline.join(meta).encode("UTF-8"))
 			f.close()
 	elif sys.argv[1] == "-oa":
-                regex = re.compile(sys.argv[2])
-                os.chdir(sys.argv[3])
-                for filename in os.listdir("."):
-                        epoch = time.mktime(time.struct_time([2000, 1, 1, 0, 0, 0, 5, 1, -1]))
-                        
-                        if not os.path.isfile(filename):
-                                print "Error!\nSpecified file doesn't exist!"
-                                sys.exit()
-                        
-                        filetype = "ppm" if filename[-3:] == "ppm" else "tmb"
-                        flipnote = TMB().ReadFile(filename) if filetype == "tmb" else PPM().ReadFile(filename, ReadFrames=False)
-                        if not flipnote:
-                                continue
+		regex = re.compile(sys.argv[2])
+		os.chdir(sys.argv[3])
+		for filename in os.listdir("."):
+			epoch = time.mktime(time.struct_time([2000, 1, 1, 0, 0, 0, 5, 1, -1]))
+			if not os.path.isfile(filename):
+				print "Error!\nSpecified file doesn't exist!"
+				sys.exit()
+				
+			filetype = "ppm" if filename[-3:] == "ppm" else "tmb"
+			flipnote = TMB().ReadFile(filename) if filetype == "tmb" else PPM().ReadFile(filename, ReadFrames=False)
+			if not flipnote:
+				continue
 
-                        meta = get_metadata(flipnote)
-                        if regex.match(meta["Original author"]):
-                                print filename
-                        
+			meta = get_metadata(flipnote)
+			if regex.match(meta["Original author"]):
+				print filename
+						
 	else:
 		print "Error!\nThere's no such mode."

--- a/PPM.py
+++ b/PPM.py
@@ -859,11 +859,12 @@ if __name__ == '__main__':
 		print "Exporting video with ffmpeg..."
 		export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-i","{path}/sounds/BGM.wav".format(path=tempdir),"-c:v","libx264","-shortest","-y",out_file]
 		if not os.path.isfile(tempdir+"/sounds/BGM.wav"):
-			has_bgm = False
-			export_command.pop(7)
-			export_command.pop(8)
+			print "No background music. Adding silent track..."
+			#has_bgm = False
+			export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-f","lavfi","-i","anullsrc=r=8192:cl=mono","-c:v","libx264","-shortest","-y",out_file]
 		else:
-			has_bgm = True
+			#has_bgm = True
+			pass
 		with open(os.devnull) as null:
 			subprocess.call(export_command,stdout=null,stderr=null)
 		print "Done!"

--- a/UGO.py
+++ b/UGO.py
@@ -51,19 +51,19 @@ def DecAsc(dec, length=None, LittleEndian=False):#Converts a decimal into an asc
 def zipalign(length, r=4):
 	return length + (4 - length % r) if length % r else length
 def indentXML(elem, level=0):#"borrowed" from: http://effbot.org/zone/element-lib.htm#prettyprint
-    i = "\n" + level*"\t"
-    if len(elem):
-        if not elem.text or not elem.text.strip():
-            elem.text = i + "\t"
-        if not elem.tail or not elem.tail.strip():
-            elem.tail = i
-        for elem in elem:
-            indentXML(elem, level+1)
-        if not elem.tail or not elem.tail.strip():
-            elem.tail = i
-    else:
-        if level and (not elem.tail or not elem.tail.strip()):
-            elem.tail = i
+	i = "\n" + level*"\t"
+	if len(elem):
+		if not elem.text or not elem.text.strip():
+			elem.text = i + "\t"
+		if not elem.tail or not elem.tail.strip():
+			elem.tail = i
+		for elem in elem:
+			indentXML(elem, level+1)
+		if not elem.tail or not elem.tail.strip():
+			elem.tail = i
+	else:
+		if level and (not elem.tail or not elem.tail.strip()):
+			elem.tail = i
 
 #class UGO:
 class UGO:

--- a/speeds.md
+++ b/speeds.md
@@ -1,0 +1,32 @@
+# Flipnote Speeds #
+
+This is some reference material taken from http://flipnote.wikia.com/wiki/Flipnote_Speed regarding flipnote speeds.
+
+## Flipnote Studio 3D ##
+
+|Speed|FPS|
+|:===:|:=:|
+|0    |0.2|
+|1    |0.5|
+|2    |1  |
+|3    |2  |
+|4    |4  |
+|5    |6  |
+|6    |8  |
+|7    |12 |
+|8    |20 |
+|9    |22 |
+|10   |29 |
+
+## Flipnote Studio DSi ##
+
+|Speed|FPS|
+|:===:|:=:|
+|1    |0.5|
+|2    |1  |
+|3    |2  |
+|4    |4  |
+|5    |6  |
+|6    |12 |
+|7    |20 |
+|8    |30 |

--- a/speeds.md
+++ b/speeds.md
@@ -5,7 +5,7 @@ This is some reference material taken from http://flipnote.wikia.com/wiki/Flipno
 ## Flipnote Studio 3D ##
 
 |Speed|FPS|
-|:===:|:=:|
+|:---:|:-:|
 |0    |0.2|
 |1    |0.5|
 |2    |1  |
@@ -21,7 +21,7 @@ This is some reference material taken from http://flipnote.wikia.com/wiki/Flipno
 ## Flipnote Studio DSi ##
 
 |Speed|FPS|
-|:===:|:=:|
+|:---:|:-:|
 |1    |0.5|
 |2    |1  |
 |3    |2  |


### PR DESCRIPTION
Requires ffmpeg, and the function will be disabled if ffmpeg is not detected.

Syntax of the command: `PPM.py -e <flipnote file> <output file>`

Only exports .MKV format files, as these allow a lot more freedom in terms of codecs, which allows the flipnotes to be exported with maximum quality.

All frames are extracted and arranged with ffmpeg to make a video. Background music is extracted and the sample rate adjusted so that sped-up background music plays at the correct speed. This is inserted into the video file. Sound effects are sequentially added at the appropriate positions by prepending silence and then mixing the video's sound with the sound effect track.