### PR TITLE
Reduce lossy transcodes in flipnote export

### DIFF
--- a/PPM.py
+++ b/PPM.py
@@ -896,14 +896,14 @@ if __name__ == '__main__':
 			pass
 		# use libx265 in lossless mode, rather than MPNG
 		if sys.argv[1] == "-E":
-                        # insert the necessary arguments into the existing command
-                        codec_index = export_command.index("-c:v")
-                        export_command[codec_index+1] = "libx265"
-                        export_command.insert(codec_index+2, "-x265-params")
-                        export_command.insert(codec_index+3, "lossless=1")
-                        export_command.insert(codec_index+2, "-preset")
-                        export_command.insert(codec_index+3, "veryslow")
-                print " ".join(export_command)
+			# insert the necessary arguments into the existing command
+			codec_index = export_command.index("-c:v")
+			export_command[codec_index+1] = "libx265"
+			export_command.insert(codec_index+2, "-x265-params")
+			export_command.insert(codec_index+3, "lossless=1")
+			export_command.insert(codec_index+2, "-preset")
+			export_command.insert(codec_index+3, "veryslow")
+		print " ".join(export_command)
 		with open(os.devnull) as null:
 			subprocess.call(export_command,stdout=null,stderr=null)
 		print "Done!"

--- a/PPM.py
+++ b/PPM.py
@@ -900,7 +900,9 @@ if __name__ == '__main__':
                         codec_index = export_command.index("-c:v")
                         export_command[codec_index+1] = "libx265"
                         export_command.insert(codec_index+2, "-x265-params")
-                        export_command.insert(codec_index+3, "lossless=1:preset=veryslow")
+                        export_command.insert(codec_index+3, "lossless=1")
+                        export_command.insert(codec_index+2, "-preset")
+                        export_command.insert(codec_index+3, "veryslow")
                 print " ".join(export_command)
 		with open(os.devnull) as null:
 			subprocess.call(export_command,stdout=null,stderr=null)

--- a/PPM.py
+++ b/PPM.py
@@ -671,7 +671,8 @@ if __name__ == '__main__':
 		print "          -f: Extracts the frame(s) to <Output>"
 		print "          -s: Dumps the sound files to the folder <Output>"
 		print "          -S: Same as mode -s, but will also dump the raw sound data files"
-		print "          -e: Exports the flipnote to an MKV"
+		print "          -e: Exports the flipnote to an MKV with minimal transcoding"
+		print "          -E: Same as -e, but will encode the video as lossless H.265"
 		print "          -m: Prints out the metadata. Can also write it to <output> which also"
 		print "              supports unicode charactes."
 		print "          -oa: Seach a directory for an original author that matches the RegEx"
@@ -822,7 +823,7 @@ if __name__ == '__main__':
 			if regex.match(meta["Original author"]):
 				print filename
 
-	elif sys.argv[1] == "-e":
+	elif sys.argv[1] == "-e" or sys.argv[1] == "-E":
 		if not hasffmpeg:
 			print "Error!\nffmpeg is not installed."
 			sys.exit()
@@ -885,14 +886,22 @@ if __name__ == '__main__':
 
 		# Now to make the video in ffmpeg
 		print "Exporting video with ffmpeg..."
-		export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-i","{path}/sounds/BGM.wav".format(path=tempdir),"-c:v","libx264","-preset","veryslow","-c:a","pcm_s16le","-t","{dur}".format(dur=duration),"-y",out_file]
+		export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-i","{path}/sounds/BGM.wav".format(path=tempdir),"-c:v","copy","-c:a","copy","-t","{dur}".format(dur=duration),"-y",out_file]
 		if not os.path.isfile(tempdir+"/sounds/BGM.wav"):
 			print "No background music. Adding silent track..."
 			#has_bgm = False
-			export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-f","lavfi","-i","anullsrc=r=8192:cl=mono","-c:v","libx264","-preset","veryslow","-c:a","pcm_s16le","-shortest","-y",out_file]
+			export_command = ["ffmpeg","-framerate",str(fps),"-start_number","1","-i","{path}/frame %03d.png".format(path=tempdir),"-f","lavfi","-i","anullsrc=r=8192:cl=mono","-c:v","copy","-c:a","pcm_s16le","-shortest","-y",out_file]
 		else:
 			#has_bgm = True
 			pass
+		# use libx265 in lossless mode, rather than MPNG
+		if sys.argv[1] == "-E":
+                        # insert the necessary arguments into the existing command
+                        codec_index = export_command.index("-c:v")
+                        export_command[codec_index+1] = "libx265"
+                        export_command.insert(codec_index+2, "-x265-params")
+                        export_command.insert(codec_index+3, "crf=0:lossless=1:preset=veryslow:qp=0")
+                print " ".join(export_command)
 		with open(os.devnull) as null:
 			subprocess.call(export_command,stdout=null,stderr=null)
 		print "Done!"

--- a/PPM.py
+++ b/PPM.py
@@ -900,7 +900,7 @@ if __name__ == '__main__':
                         codec_index = export_command.index("-c:v")
                         export_command[codec_index+1] = "libx265"
                         export_command.insert(codec_index+2, "-x265-params")
-                        export_command.insert(codec_index+3, "crf=0:lossless=1:preset=veryslow:qp=0")
+                        export_command.insert(codec_index+3, "lossless=1:preset=veryslow")
                 print " ".join(export_command)
 		with open(os.devnull) as null:
 			subprocess.call(export_command,stdout=null,stderr=null)


### PR DESCRIPTION
Current export implementation encodes the video as H.264. This is good for compatibility, but is a lossy encoding. The transcoding is not actually necessary, however; the MKV container supports an MPNG stream. The exported frames can essentially just be copied directly into the output stream, removing the need to perform a lossy encoding. This may be advantageous for archivers. There is generally no transcoding occurring for the audio stream (it is already kept in WAV format through the entire export process), but for flipnotes with sound effects, the sound effects are injected into background music. As far as I know, this cannot be avoided if BGM and sound effects are to be included in the export (in this case, storing the sound exports alongside the video export would probably be the best way to archive it).

For greater compatibility (I've noticed, for example, that VLC displays MPNG streams poorly), I've also added the `-E` option, which performs the same export but will encode the video as a lossless H.265 stream. Whilst this is a transcode, libx264 and libx265 both support lossless encoding, hence nothing should be lost in this conversion. However, the [ffmpeg documentation](https://trac.ffmpeg.org/wiki/Encode/H.264#LosslessH.264) suggests that, while this may have better compatibility than MPNG, the compatibility is still limited to ffmpeg-based players (though I've found lossless H.265 tends to have better compatibility than lossless H.264 among players that support H.265).

In either case, the user can re-encode the video in a more compatible format if necessary; this simply aims to update the command to preserve as much information as possible in the initial export process.

Hopefully this can be of benefit to any other data hoarders out there like myself.